### PR TITLE
feat: Support "alquerque" and "marbles" bit and board pieces

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: ppcli
 Type: Package
 Title: Plaintext Board Game Visualizations
-Version: 0.1.1
+Version: 0.2.0-1
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")))
@@ -24,6 +24,7 @@ Suggests:
     ppdf,
     testthat,
     tibble,
+    withr
 Remotes: piecepackr/ppdf
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,11 +3,12 @@ ppcli 0.2.0 (development)
 
 * `cat_piece()` and `str_piece()` adds support for the following game pieces (#4):
 
+  + "alquerque" bit and board pieces.
   + "marbles" bit and board pieces.
 
     - However we currently do not distinguish between the nine marble bit ranks.
 
-* "white" `go` and `chess` bits should now render the same
+* "white" `go` and `checkers` bits should now render the same
   whether `piece_side` is `"bit_back"` or `"bit_face"`.
 
 ppcli 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+ppcli 0.2.0 (development)
+=========================
+
+* `cat_piece()` and `str_piece()` adds support for the following game pieces (#4):
+
+  + "marbles" bit and board pieces.
+
+    - However we currently do not distinguish between the nine marble bit ranks.
+
+* "white" `go` and `chess` bits should now render the same
+  whether `piece_side` is `"bit_back"` or `"bit_face"`.
+
 ppcli 0.1.1
 ===========
 
@@ -9,4 +21,3 @@ ppcli 0.1.1
   + It is an extraction and refinement of ``ppgames::cat_piece()``.
 
 * ``str_piece()`` computes the character vector of Unicode plaintext boardgame diagrams (#1).
-

--- a/tests/testthat/_snaps/cat_piece.md
+++ b/tests/testthat/_snaps/cat_piece.md
@@ -532,3 +532,38 @@
                                               
                                               
 
+---
+
+    Code
+      withr::local_seed(42)
+      dfb <- tibble(piece_side = "board_face", suit = 4L, rank = 4L, cfg = "marbles",
+        x = 2, y = 2)
+      dfm <- tibble(piece_side = "bit_face", suit = sample.int(6L, 30L, replace = TRUE),
+      rank = 9L, cfg = "marbles", x = c(0.5 + rep(0:3, 4L), rep(rep(1:3, 3L)), 0.5 +
+        rep(1:2, 2L), 2), y = c(0.5 + rep(0:3, each = 4L), rep(1:3, each = 3L), 0.5 +
+        rep(1:2, each = 2L), 2))
+      df <- rbind(dfb, dfm)
+      cat_piece(dfb)
+    Output
+      ┌───────┐
+      │◌ ◌ ◌ ◌│
+      │       │
+      │◌ ◌ ◌ ◌│
+      │       │
+      │◌ ◌ ◌ ◌│
+      │       │
+      │◌ ◌ ◌ ◌│
+      └───────┘
+    Code
+      cat_piece(df)
+    Output
+      ┌───────┐
+      │○ ● ● ●│
+      │ ● ● ● │
+      │● ● ● ●│
+      │ ● ● ● │
+      │● ● ● ●│
+      │ ● ● ● │
+      │● ● ● ●│
+      └───────┘
+

--- a/tests/testthat/_snaps/cat_piece.md
+++ b/tests/testthat/_snaps/cat_piece.md
@@ -567,3 +567,38 @@
       │● ● ● ●│
       └───────┘
 
+---
+
+    Code
+      dfb <- tibble(piece_side = "board_face", x = 3, y = 3, suit = 3, cfg = "alquerque")
+      dfs <- tibble(piece_side = "bit_back", x = 1:5, y = 1:5, suit = 1:5, cfg = "alquerque")
+      df <- rbind(dfb, dfs)
+      cat_piece(dfb)
+    Output
+        ┌─┬─┬─┬─┐
+        │╲│╱│╲│╱│
+        ├─┼─┼─┼─┤
+        │╱│╲│╱│╲│
+        ├─┼─┼─┼─┤
+        │╲│╱│╲│╱│
+        ├─┼─┼─┼─┤
+        │╱│╲│╱│╲│
+        └─┴─┴─┴─┘
+                 
+                 
+    Code
+      cat_piece(df)
+    Output
+                  
+        ┌─┬─┬─┬─● 
+        │╲│╱│╲│╱│ 
+        ├─┼─┼─●─┤ 
+        │╱│╲│╱│╲│ 
+        ├─┼─●─┼─┤ 
+        │╲│╱│╲│╱│ 
+        ├─●─┼─┼─┤ 
+        │╱│╲│╱│╲│ 
+        ●─┴─┴─┴─┘ 
+                  
+                  
+

--- a/tests/testthat/test_cat_piece.r
+++ b/tests/testthat/test_cat_piece.r
@@ -3,6 +3,7 @@ cat_piece <- function(df, ...) ppcli::cat_piece(df, ..., color = FALSE)
 test_that("text diagrams", {
     skip_if_not_installed("dplyr")
     skip_if_not_installed("tibble")
+    skip_if_not_installed("withr")
     library("tibble")
 
     style <- get_style("unicode")
@@ -163,6 +164,24 @@ test_that("text diagrams", {
         dfs <- tibble(piece_side = "bit_back", x = 1:19, y = 1:19,
                       suit = 1:19 %% 6 + 1, cfg = "go")
         df <- dplyr::bind_rows(dfb, dfs)
+        cat_piece(df)
+    })
+
+    # marbles
+    expect_snapshot({
+        withr::local_seed(42)
+        dfb <- tibble(piece_side = "board_face", suit = 4L, rank = 4L,
+                      cfg ="marbles", x = 2, y = 2)
+        dfm <- tibble(
+            piece_side = "bit_face",
+            suit = sample.int(6L, 30L, replace = TRUE),
+            rank = 9L,
+            cfg = "marbles",
+            x = c(0.5 + rep(0:3, 4L), rep(rep(1:3, 3L)), 0.5 + rep(1:2, 2L), 2),
+            y = c(0.5 + rep(0:3, each = 4L), rep(1:3, each = 3L), 0.5 + rep(1:2, each = 2L), 2)
+        )
+        df <- rbind(dfb, dfm)
+        cat_piece(dfb)
         cat_piece(df)
     })
 })

--- a/tests/testthat/test_cat_piece.r
+++ b/tests/testthat/test_cat_piece.r
@@ -184,4 +184,13 @@ test_that("text diagrams", {
         cat_piece(dfb)
         cat_piece(df)
     })
+
+    # alquerque
+    expect_snapshot({
+        dfb <- tibble(piece_side = "board_face", x= 3, y = 3, suit = 3, cfg = "alquerque")
+        dfs <- tibble(piece_side = "bit_back", x = 1:5, y = 1:5, suit = 1:5, cfg = "alquerque")
+        df <- rbind(dfb, dfs)
+        cat_piece(dfb)
+        cat_piece(df)
+    })
 })


### PR DESCRIPTION
* `cat_piece()` and `str_piece()` adds support for the following game pieces (#4):

  + "alquerque" bit and board pieces.
  + "marbles" bit and board pieces.

    - However we currently do not distinguish between the nine marble bit ranks.

* "white" `go` and `checkers` bits should now render the same
  whether `piece_side` is `"bit_back"` or `"bit_face"`.